### PR TITLE
Bump setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 install_requires =
     ghga-service-chassis-lib[mongo_connect]==0.17.7
     metadata-search-service==0.1.0
-    
+    setuptools>=65.5.1
     # Copied and bumped from ghga-service-chassis-lib[api]
     fastapi>=0.103.1
     uvicorn[standard]>=0.23.2
@@ -55,7 +55,6 @@ console_scripts =
 # Please adapt:
 dev =
     ghga-service-chassis-lib[dev]==0.17.7
-    setuptools>=65.5.1
 all =
     %(dev)s
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     ghga-service-chassis-lib[mongo_connect]==0.17.7
     metadata-search-service==0.1.0
     setuptools>=65.5.1
+    stringcase>=1.2.0
     # Copied and bumped from ghga-service-chassis-lib[api]
     fastapi>=0.103.1
     uvicorn[standard]>=0.23.2


### PR DESCRIPTION
Resolve vulnerability scan issue:
```
Python (python-pkg)
===================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌───────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────┐
│        Library        │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                      Title                      │
├───────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────┤
│ setuptools (METADATA) │ CVE-2022-40897 │ HIGH     │ fixed  │ 58.1.0            │ 65.5.1        │ Regular Expression Denial of Service (ReDoS) in │
│                       │                │          │        │                   │               │ package_index.py                                │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-40897      │
└───────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────┘
```